### PR TITLE
feat: log update_mt_training_stage response and verify it in test

### DIFF
--- a/eox_nelp/signals/tasks.py
+++ b/eox_nelp/signals/tasks.py
@@ -197,10 +197,18 @@ def update_mt_training_stage(course_id, national_id, stage_result):
         base_url=settings.MINISTER_OF_TOURISM_API_URL,
     )
 
-    api_client.update_training_stage(
+    response = api_client.update_training_stage(
         course_id=course_id,
         national_id=national_id,
         stage_result=stage_result,
+    )
+
+    logger.info(
+        "Called update_training_stage with course_id=%s, national_id=%s, stage_result=%s. Response: %s",
+        course_id,
+        national_id,
+        stage_result,
+        response,
     )
 
 


### PR DESCRIPTION

## Description

Adds a new log line to update_mt_training_stage to include the full API response.
Also updates the corresponding unit test to assert the exact INFO log output.

This ensures traceability of the response returned by the external service and improves confidence through explicit log validation.


