### PR TITLE
fix: teak tests adding content search app

### DIFF
--- a/eox_nelp/settings/common.py
+++ b/eox_nelp/settings/common.py
@@ -24,6 +24,7 @@ DEFAULT_FUTUREX_NOTIFY_SUBSECTION_SUBJECT_MESSAGE = (
 )
 #  APP Labels
 COURSE_CREATOR_APP = 'cms.djangoapps.course_creators'
+CONTENT_SEARCH_APP = 'openedx.core.djangoapps.content.search'
 JSON_API_REST_FRAMEWORK = 'rest_framework_json_api'
 EOX_AUDIT_MODEL_APP = 'eox_audit_model.apps.EoxAuditModelConfig'
 EOX_SUPPORT_APP = 'eox_support.apps.EoxSupportConfig'
@@ -68,6 +69,8 @@ def plugin_settings(settings):
 
     if COURSE_CREATOR_APP not in settings.INSTALLED_APPS:
         settings.INSTALLED_APPS.append(COURSE_CREATOR_APP)
+    if find_spec(CONTENT_SEARCH_APP) and CONTENT_SEARCH_APP not in settings.INSTALLED_APPS:
+        settings.INSTALLED_APPS.append(CONTENT_SEARCH_APP)
     if find_spec(JSON_API_REST_FRAMEWORK) and JSON_API_REST_FRAMEWORK not in settings.INSTALLED_APPS:
         settings.INSTALLED_APPS.append(JSON_API_REST_FRAMEWORK)
     if find_spec('eox_audit_model') and EOX_AUDIT_MODEL_APP not in settings.INSTALLED_APPS:


### PR DESCRIPTION
This is to integrate receiver of registering djangoapp `openedx.core.djangoapps.content.search`.

This could include snowball problems, by adding support to this line of the past.
https://github.com/nelc/eox-nelp/commit/a6610cea938bebeb6aa952b2dc2a0a8ffa891569

Fixes model class import running teak tests.
`RuntimeError: Model class openedx.core.djangoapps.content.search.models.SearchAccess doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS. `

https://github.com/nelc/eox-nelp/actions/runs/17000131868/job/48200080600

<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.

Useful information to include:
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Testing instructions

### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
